### PR TITLE
fix(api): add /status health check endpoint

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -17,3 +17,7 @@ async def test_api():
 @router.get("/test")
 async def test_api_for_deployment():
     return 'API is working (test)'
+
+@router.get("/status")
+async def health_check():
+    return {"status": "ok"}


### PR DESCRIPTION
## Summary

- Add `GET /status` endpoint returning `{"status": "ok"}`
- Required for K8S startup, readiness, and liveness probes
- Without this, all probes return 404 → pod killed during rollout → deployment never succeeds

## Context

The ACK deployment uses `/status` as the health check path. The app only had `/` and `/test` endpoints, causing all probes to fail with 404.

Made with [Cursor](https://cursor.com)